### PR TITLE
Package up contract sources

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,17 @@
           ];
         };
 
+        contracts = pkgs.stdenv.mkDerivation {
+          pname = "mx-sdk-contracts";
+          version = "0.50.1";
+          src = mx-sdk-rs-src;
+          dontBuild = true;
+          installPhase = ''
+            mkdir $out
+            cp -R contracts/* $out
+          '';
+        };
+
         make-test = sc-meta: pkgs.stdenv.mkDerivation {
           pname = "sc-meta-test";
           version = "0";
@@ -61,6 +72,7 @@
         };
       in rec {
         packages = {
+          inherit (pkgs) contracts;
           sc-meta = (pkgs.rustPkgs.workspace.multiversx-sc-meta {});
           test = pkgs.make-test packages.sc-meta;
           default = packages.sc-meta;


### PR DESCRIPTION
As well as the `sc-meta` tool, the testing setup for the MX Semantics requires that we have access to the source code for the example contracts packaged as part of the SDK distribution.

This PR adds a new package output to the Nix flake for the SDK that exposes these contract sources as a source distribution.

Closes #4 